### PR TITLE
Waid Cache Removel

### DIFF
--- a/otpless-android-sdk/build.gradle
+++ b/otpless-android-sdk/build.gradle
@@ -11,8 +11,8 @@ android {
 
         minSdkVersion 17
         targetSdkVersion 33
-        versionCode 115
-        versionName "1.1.5"
+        versionCode 116
+        versionName "1.1.6"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "OTPLESS_VERSION_NAME", "\"" + versionName + "\"")

--- a/otpless-android-sdk/src/main/java/com/otpless/utils/Utility.java
+++ b/otpless-android-sdk/src/main/java/com/otpless/utils/Utility.java
@@ -47,13 +47,6 @@ public class Utility {
         return str != null && str.length() > 0;
     }
 
-    public static void deleteWaId(final Context context) {
-        SharedPreferences sp = context.getSharedPreferences("otpless_storage_manager", Context.MODE_PRIVATE);
-        SharedPreferences.Editor editor = sp.edit();
-        editor.remove("otpless_waid");
-        editor.apply();
-    }
-
     public static String getUrlWithDeviceParams(Context context, String url){
         if (url == null)
             return url;

--- a/otpless-android-sdk/src/main/java/com/otpless/views/OtplessManager.java
+++ b/otpless-android-sdk/src/main/java/com/otpless/views/OtplessManager.java
@@ -107,13 +107,6 @@ public class OtplessManager {
     }
 
     /**
-     * NOT RECOMMENDED until and unless these is a specific requirement to clear all session
-     */
-    public void signOut(final Context context){
-        Utility.deleteWaId(context);
-    }
-
-    /**
      * return string array of length 6
      */
     public String[] getConfiguration(final Context context) {

--- a/otpless-android-sdk/src/main/java/com/otpless/views/WhatsappLoginButton.java
+++ b/otpless-android-sdk/src/main/java/com/otpless/views/WhatsappLoginButton.java
@@ -9,9 +9,6 @@ import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
-import android.graphics.drawable.ShapeDrawable;
-import android.graphics.drawable.shapes.RoundRectShape;
-import android.graphics.drawable.shapes.Shape;
 import android.net.Uri;
 import android.util.AttributeSet;
 import android.util.DisplayMetrics;
@@ -27,12 +24,9 @@ import androidx.lifecycle.LifecycleObserver;
 
 import com.otpless.R;
 import com.otpless.dto.OtplessResponse;
-import com.otpless.network.ApiCallback;
 import com.otpless.network.ApiManager;
 import com.otpless.utils.SchemeHostMetaInfo;
 import com.otpless.utils.Utility;
-
-import org.json.JSONObject;
 
 public class WhatsappLoginButton extends ConstraintLayout implements View.OnClickListener, LifecycleObserver {
 
@@ -183,31 +177,6 @@ public class WhatsappLoginButton extends ConstraintLayout implements View.OnClic
             ApiManager.getInstance().baseUrl = baseUrl;
             OtplessManager.getInstance().redirectUrl = this.otplessLink;
         }
-        checkForWaid();
-    }
-
-    private void checkForWaid() {
-        final String waid = getContext().getSharedPreferences("otpless_storage_manager", Context.MODE_PRIVATE).getString("otpless_waid", null);
-        if (waid == null) {
-            return;
-        }
-        ApiManager.getInstance().verifyWaId(
-                waid, new ApiCallback<JSONObject>() {
-                    @Override
-                    public void onSuccess(JSONObject data) {
-                        final String userNumber = Utility.parseUserNumber(data);
-                        if (Utility.isNotEmpty(userNumber)) {
-                            setText(userNumber);
-                        }
-                    }
-
-                    @Override
-                    public void onError(Exception exception) {
-                        exception.printStackTrace();
-                        Utility.deleteWaId(getContext());
-                    }
-                }
-        );
     }
 
     private void onOtplessResult(@Nullable OtplessResponse userDetail) {


### PR DESCRIPTION
### This PR is regarding the waid cache, pre authentication without redirecting to WhatsApp from native end removal ###

**Following changes done**
* `deleteWaid` and `signout` method removed from `Utility` class.
* `checkWaidStatus` method removed from `WhatsappLoginButton`.
* Api call for `waid` verification by getting its value from storage removed from initView method of `OtplessLoginActivity`.
* Storing waid in Shared Pref on success of verification removed.