### PR TITLE
BugFix: Class cast exception while searching parent view

### DIFF
--- a/otpless-android-sdk/build.gradle
+++ b/otpless-android-sdk/build.gradle
@@ -11,8 +11,8 @@ android {
 
         minSdkVersion 17
         targetSdkVersion 33
-        versionCode 216
-        versionName "2.1.6"
+        versionCode 217
+        versionName "2.1.7"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "OTPLESS_VERSION_NAME", "\"" + versionName + "\"")

--- a/otpless-android-sdk/publish-otpless.gradle
+++ b/otpless-android-sdk/publish-otpless.gradle
@@ -3,7 +3,7 @@ apply plugin: 'signing'
 
 
 def PUBLISH_ARTIFACT_ID = "otpless-android-sdk"
-def PUBLISH_DESCRIPTION = "No internet connectivity callback support and view."
+def PUBLISH_DESCRIPTION = "Bug fix: class casting exception on searching view."
 
 LinkedHashMap<String, String> getOssrhCredentials() {
     def home = System.getenv("HOME")
@@ -44,7 +44,7 @@ signing {
 }
 
 group = "io.github.otpless-tech"
-version = "2.1.6"
+version = "2.1.7"
 
 uploadArchives {
     repositories {

--- a/otpless-android-sdk/src/main/java/com/otpless/dto/OtplessRequest.java
+++ b/otpless-android-sdk/src/main/java/com/otpless/dto/OtplessRequest.java
@@ -7,12 +7,20 @@ import com.otpless.utils.Utility;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class OtplessRequest {
 
     @NonNull
     private String cid = "";
     @NonNull
     private String uxmode = "";
+
+    @NonNull
+    private String locale = "";
+
+    private HashMap<String, String> mExtras = new HashMap<>();
 
     public OtplessRequest setCid(@NonNull String cid) {
         this.cid = cid;
@@ -24,10 +32,21 @@ public class OtplessRequest {
         return this;
     }
 
+    public OtplessRequest setLocale(@NonNull String locale) {
+        this.locale = locale;
+        return this;
+    }
+
+    public OtplessRequest addExtras(@NonNull final String key, @NonNull final  String value) {
+        mExtras.put(key, value);
+        return this;
+    }
+
     public JSONObject toJsonObj() {
         final JSONObject extra = new JSONObject();
         try {
             extra.put("method", "get");
+            //region adding data in params
             final JSONObject params = new JSONObject();
             if (Utility.isValid(cid)) {
                 params.put("cid", cid);
@@ -35,6 +54,14 @@ public class OtplessRequest {
             if (Utility.isValid(uxmode)) {
                 params.put("uxmode", uxmode);
             }
+            if (Utility.isValid(locale)) {
+                params.put("locale", locale);
+            }
+            for (Map.Entry<String, String> entry: mExtras.entrySet()) {
+                params.put(entry.getKey(), entry.getValue());
+            }
+            //endregion
+            // adding params in extras
             extra.put("params", params);
         } catch (JSONException ignore) {
         }

--- a/otpless-android-sdk/src/main/java/com/otpless/dto/OtplessRequest.java
+++ b/otpless-android-sdk/src/main/java/com/otpless/dto/OtplessRequest.java
@@ -1,0 +1,43 @@
+package com.otpless.dto;
+
+import androidx.annotation.NonNull;
+
+import com.otpless.utils.Utility;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class OtplessRequest {
+
+    @NonNull
+    private String cid = "";
+    @NonNull
+    private String uxmode = "";
+
+    public OtplessRequest setCid(@NonNull String cid) {
+        this.cid = cid;
+        return this;
+    }
+
+    public OtplessRequest setUxmode(@NonNull String uxmode) {
+        this.uxmode = uxmode;
+        return this;
+    }
+
+    public JSONObject toJsonObj() {
+        final JSONObject extra = new JSONObject();
+        try {
+            extra.put("method", "get");
+            final JSONObject params = new JSONObject();
+            if (Utility.isValid(cid)) {
+                params.put("cid", cid);
+            }
+            if (Utility.isValid(uxmode)) {
+                params.put("uxmode", uxmode);
+            }
+            extra.put("params", params);
+        } catch (JSONException ignore) {
+        }
+        return extra;
+    }
+}

--- a/otpless-android-sdk/src/main/java/com/otpless/main/OtplessView.java
+++ b/otpless-android-sdk/src/main/java/com/otpless/main/OtplessView.java
@@ -2,6 +2,7 @@ package com.otpless.main;
 
 import android.content.Intent;
 
+import com.otpless.dto.OtplessRequest;
 import com.otpless.views.FabButtonAlignment;
 import com.otpless.views.OtplessUserDetailCallback;
 
@@ -11,8 +12,12 @@ public interface OtplessView {
     /// methods to start otpless
     void startOtpless(final JSONObject params);
 
+    void startOtpless(final OtplessRequest request);
+
     /// method to start otpless with with json parameters
     void startOtpless(final JSONObject params, final OtplessUserDetailCallback callback);
+
+    void startOtpless(final OtplessRequest request, final OtplessUserDetailCallback callback);
 
     /// methods to start otpless
     void startOtpless();
@@ -21,6 +26,10 @@ public interface OtplessView {
     void setCallback(final OtplessUserDetailCallback callback, final JSONObject extra);
 
     void setCallback(final OtplessUserDetailCallback callback, final JSONObject extra, final boolean isLoginPage);
+
+    void setCallback(final OtplessRequest request, final OtplessUserDetailCallback callback);
+
+    void setCallback(final OtplessRequest request, final OtplessUserDetailCallback callback, final boolean isLoginPage);
 
     /// explicitly closing the view
     void closeView();
@@ -49,6 +58,8 @@ public interface OtplessView {
 
     /// to show otpless login page with extra and callback
     void showOtplessLoginPage(final JSONObject extra, OtplessUserDetailCallback callback);
+
+    void showOtplessLoginPage(final OtplessRequest request, OtplessUserDetailCallback callback);
 
     /// to show otpless login page with callback
     void showOtplessLoginPage(OtplessUserDetailCallback callback);

--- a/otpless-android-sdk/src/main/java/com/otpless/main/OtplessView.java
+++ b/otpless-android-sdk/src/main/java/com/otpless/main/OtplessView.java
@@ -2,6 +2,8 @@ package com.otpless.main;
 
 import android.content.Intent;
 
+import androidx.annotation.NonNull;
+
 import com.otpless.dto.OtplessRequest;
 import com.otpless.views.FabButtonAlignment;
 import com.otpless.views.OtplessUserDetailCallback;
@@ -13,13 +15,13 @@ public interface OtplessView {
     @Deprecated
     void startOtpless(final JSONObject params);
 
-    void startOtpless(final OtplessRequest request);
+    void startOtpless(final OtplessUserDetailCallback callback);
 
     /// method to start otpless with with json parameters
     @Deprecated
     void startOtpless(final JSONObject params, final OtplessUserDetailCallback callback);
 
-    void startOtpless(final OtplessRequest request, final OtplessUserDetailCallback callback);
+    void startOtpless(@NonNull final OtplessRequest request, final OtplessUserDetailCallback callback);
 
     /// methods to start otpless
     void startOtpless();
@@ -30,9 +32,9 @@ public interface OtplessView {
 
     void setCallback(final OtplessUserDetailCallback callback, final JSONObject extra, final boolean isLoginPage);
 
-    void setCallback(final OtplessRequest request, final OtplessUserDetailCallback callback);
+    void setCallback(final OtplessUserDetailCallback callback, final boolean isLoginPage);
 
-    void setCallback(final OtplessRequest request, final OtplessUserDetailCallback callback, final boolean isLoginPage);
+    void setCallback(@NonNull final OtplessRequest request, final OtplessUserDetailCallback callback, final boolean isLoginPage);
 
     /// explicitly closing the view
     void closeView();
@@ -62,7 +64,7 @@ public interface OtplessView {
     /// to show otpless login page with extra and callback
     void showOtplessLoginPage(final JSONObject extra, OtplessUserDetailCallback callback);
 
-    void showOtplessLoginPage(final OtplessRequest request, OtplessUserDetailCallback callback);
+    void showOtplessLoginPage(@NonNull final OtplessRequest request, OtplessUserDetailCallback callback);
 
     /// to show otpless login page with callback
     void showOtplessLoginPage(OtplessUserDetailCallback callback);

--- a/otpless-android-sdk/src/main/java/com/otpless/main/OtplessView.java
+++ b/otpless-android-sdk/src/main/java/com/otpless/main/OtplessView.java
@@ -10,11 +10,13 @@ import org.json.JSONObject;
 
 public interface OtplessView {
     /// methods to start otpless
+    @Deprecated
     void startOtpless(final JSONObject params);
 
     void startOtpless(final OtplessRequest request);
 
     /// method to start otpless with with json parameters
+    @Deprecated
     void startOtpless(final JSONObject params, final OtplessUserDetailCallback callback);
 
     void startOtpless(final OtplessRequest request, final OtplessUserDetailCallback callback);
@@ -23,6 +25,7 @@ public interface OtplessView {
     void startOtpless();
 
     /// explicitly setting the callback
+    @Deprecated
     void setCallback(final OtplessUserDetailCallback callback, final JSONObject extra);
 
     void setCallback(final OtplessUserDetailCallback callback, final JSONObject extra, final boolean isLoginPage);

--- a/otpless-android-sdk/src/main/java/com/otpless/main/OtplessViewImpl.java
+++ b/otpless-android-sdk/src/main/java/com/otpless/main/OtplessViewImpl.java
@@ -14,6 +14,7 @@ import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 
 import com.otpless.R;
+import com.otpless.dto.OtplessRequest;
 import com.otpless.dto.OtplessResponse;
 import com.otpless.network.ApiCallback;
 import com.otpless.network.ApiManager;
@@ -72,12 +73,33 @@ final class OtplessViewImpl implements OtplessView, OtplessViewContract, OnConne
     }
 
     @Override
+    public void startOtpless(final OtplessRequest request) {
+        if (request != null) {
+            this.startOtpless(request.toJsonObj());
+        } else {
+            this.startOtpless();
+        }
+    }
+
+    @Override
     public void startOtpless(JSONObject params, OtplessUserDetailCallback callback) {
         this.detailCallback = callback;
         this.extras = params;
         this.isLoginPageEnabled = false;
         addViewIfNotAdded();
         loadWebView(null, null);
+    }
+
+    @Override
+    public void startOtpless(final OtplessRequest request, final OtplessUserDetailCallback callback) {
+        if (request != null) {
+            this.startOtpless(request.toJsonObj(), callback);
+        } else {
+            this.detailCallback = callback;
+            this.isLoginPageEnabled = false;
+            this.startOtpless();
+        }
+
     }
 
     @Override
@@ -182,6 +204,21 @@ final class OtplessViewImpl implements OtplessView, OtplessViewContract, OnConne
         this.detailCallback = callback;
         this.extras = extra;
         this.isLoginPageEnabled = isLoginPage;
+    }
+
+    @Override
+    public void setCallback(final OtplessRequest request, final OtplessUserDetailCallback callback) {
+        this.setCallback(request, callback, false);
+    }
+
+    @Override
+    public void setCallback(final OtplessRequest request, final OtplessUserDetailCallback callback ,final boolean isLoginPage) {
+        if (request != null) {
+            this.setCallback(callback, request.toJsonObj(), isLoginPage);
+        } else {
+            this.detailCallback = callback;
+            this.isLoginPageEnabled = isLoginPage;
+        }
     }
 
     @Override
@@ -527,6 +564,15 @@ final class OtplessViewImpl implements OtplessView, OtplessViewContract, OnConne
         this.setCallback(callback, null, true);
         addViewIfNotAdded();
         loadWebView(null, null);
+    }
+
+    @Override
+    public void showOtplessLoginPage(final OtplessRequest request, OtplessUserDetailCallback callback) {
+        JSONObject extra = null;
+        if (request != null) {
+            extra = request.toJsonObj();
+        }
+        this.showOtplessLoginPage(extra, callback);
     }
 
     @Override

--- a/otpless-android-sdk/src/main/java/com/otpless/main/OtplessViewImpl.java
+++ b/otpless-android-sdk/src/main/java/com/otpless/main/OtplessViewImpl.java
@@ -73,12 +73,9 @@ final class OtplessViewImpl implements OtplessView, OtplessViewContract, OnConne
     }
 
     @Override
-    public void startOtpless(final OtplessRequest request) {
-        if (request != null) {
-            this.startOtpless(request.toJsonObj());
-        } else {
-            this.startOtpless();
-        }
+    public void startOtpless(OtplessUserDetailCallback callback) {
+        this.detailCallback = callback;
+        this.startOtpless();
     }
 
     @Override
@@ -91,15 +88,11 @@ final class OtplessViewImpl implements OtplessView, OtplessViewContract, OnConne
     }
 
     @Override
-    public void startOtpless(final OtplessRequest request, final OtplessUserDetailCallback callback) {
-        if (request != null) {
-            this.startOtpless(request.toJsonObj(), callback);
-        } else {
-            this.detailCallback = callback;
-            this.isLoginPageEnabled = false;
-            this.startOtpless();
-        }
-
+    public void startOtpless(@NonNull final OtplessRequest request, final OtplessUserDetailCallback callback) {
+        this.extras = request.toJsonObj();
+        this.detailCallback = callback;
+        this.isLoginPageEnabled = false;
+        this.startOtpless();
     }
 
     @Override
@@ -207,18 +200,15 @@ final class OtplessViewImpl implements OtplessView, OtplessViewContract, OnConne
     }
 
     @Override
-    public void setCallback(final OtplessRequest request, final OtplessUserDetailCallback callback) {
-        this.setCallback(request, callback, false);
+    public void setCallback(final OtplessUserDetailCallback callback, final boolean isLoginPage) {
+        this.setCallback(callback, null, isLoginPage);
     }
 
     @Override
-    public void setCallback(final OtplessRequest request, final OtplessUserDetailCallback callback ,final boolean isLoginPage) {
-        if (request != null) {
-            this.setCallback(callback, request.toJsonObj(), isLoginPage);
-        } else {
-            this.detailCallback = callback;
-            this.isLoginPageEnabled = isLoginPage;
-        }
+    public void setCallback(@NonNull final OtplessRequest request, final OtplessUserDetailCallback callback ,final boolean isLoginPage) {
+        this.extras = request.toJsonObj();
+        this.detailCallback = callback;
+        this.isLoginPageEnabled = isLoginPage;
     }
 
     @Override
@@ -567,12 +557,12 @@ final class OtplessViewImpl implements OtplessView, OtplessViewContract, OnConne
     }
 
     @Override
-    public void showOtplessLoginPage(final OtplessRequest request, OtplessUserDetailCallback callback) {
-        JSONObject extra = null;
-        if (request != null) {
-            extra = request.toJsonObj();
-        }
-        this.showOtplessLoginPage(extra, callback);
+    public void showOtplessLoginPage(@NonNull final OtplessRequest request, OtplessUserDetailCallback callback) {
+        this.isLoginPageEnabled = true;
+        this.detailCallback = callback;
+        this.extras = request.toJsonObj();
+        addViewIfNotAdded();
+        loadWebView(null, null);
     }
 
     @Override

--- a/otpless-android-sdk/src/main/java/com/otpless/main/OtplessViewImpl.java
+++ b/otpless-android-sdk/src/main/java/com/otpless/main/OtplessViewImpl.java
@@ -33,7 +33,7 @@ import org.json.JSONObject;
 
 import java.lang.ref.WeakReference;
 import java.util.Iterator;
-import java.util.PriorityQueue;
+import java.util.LinkedList;
 import java.util.Queue;
 
 final class OtplessViewImpl implements OtplessView, OtplessViewContract, OnConnectionChangeListener, NativeWebListener {
@@ -57,7 +57,7 @@ final class OtplessViewImpl implements OtplessView, OtplessViewContract, OnConne
 
     private boolean isLoginPageEnabled = false;
 
-    private final Queue<ViewGroup> helpQueue = new PriorityQueue<>();
+    private final Queue<ViewGroup> helpQueue = new LinkedList<>();
 
     OtplessViewImpl(final Activity activity) {
         this.activity = activity;

--- a/otpless-android-sdk/src/main/java/com/otpless/main/OtplessViewImpl.java
+++ b/otpless-android-sdk/src/main/java/com/otpless/main/OtplessViewImpl.java
@@ -91,7 +91,6 @@ final class OtplessViewImpl implements OtplessView, OtplessViewContract, OnConne
     public void startOtpless(@NonNull final OtplessRequest request, final OtplessUserDetailCallback callback) {
         this.extras = request.toJsonObj();
         this.detailCallback = callback;
-        this.isLoginPageEnabled = false;
         this.startOtpless();
     }
 


### PR DESCRIPTION
**Issue:** While searching parent view BFS were using priority queue and following exception received by some clients
```
Exception java.lang.RuntimeException: Unable to destroy activity {com.graymatrix.did/auth.ui.AuthenticationActivity}: 
java.lang.ClassCastException: com.android.internal.policy.DecorView cannot be cast to java.lang.Comparable
```

**Fix**: Priority queue changed to Linked List as simple queue is needed.